### PR TITLE
Changed imports within OSL package to relative.

### DIFF
--- a/opensourceleg/demo.py
+++ b/opensourceleg/demo.py
@@ -1,7 +1,7 @@
 import time
 
-from opensourceleg.control.state_machine import Event, State, StateMachine
-from opensourceleg.osl import OpenSourceLeg
+from .control.state_machine import Event, State, StateMachine
+from .osl import OpenSourceLeg
 
 # ------------- FSM PARAMETERS ---------------- #
 

--- a/opensourceleg/hardware/actuators.py
+++ b/opensourceleg/hardware/actuators.py
@@ -10,8 +10,8 @@ import flexsea.fx_enums as fxe
 import numpy as np
 from flexsea.device import Device
 
-from opensourceleg.hardware.thermal import ThermalModel
-from opensourceleg.tools.logger import Logger
+from ..tools.logger import Logger
+from .thermal import ThermalModel
 
 
 @dataclass

--- a/opensourceleg/hardware/joints.py
+++ b/opensourceleg/hardware/joints.py
@@ -3,7 +3,8 @@ import time
 
 import numpy as np
 
-from opensourceleg.hardware.actuators import (
+from ..tools.logger import Logger
+from .actuators import (
     MAX_CASE_TEMPERATURE,
     NM_PER_RAD_TO_K,
     NM_S_PER_RAD_TO_B,
@@ -11,7 +12,6 @@ from opensourceleg.hardware.actuators import (
     DephyActpack,
     MockDephyActpack,
 )
-from opensourceleg.tools.logger import Logger
 
 
 class Joint(DephyActpack):

--- a/opensourceleg/hardware/sensors.py
+++ b/opensourceleg/hardware/sensors.py
@@ -9,8 +9,8 @@ import numpy as np
 import numpy.typing as npt
 from smbus2 import SMBus
 
-from opensourceleg.hardware.joints import Joint
-from opensourceleg.tools.logger import Logger
+from ..tools.logger import Logger
+from .joints import Joint
 
 
 class StrainAmp:

--- a/opensourceleg/osl.py
+++ b/opensourceleg/osl.py
@@ -6,11 +6,11 @@ import numpy as np
 
 sys.path.append("../")
 
-import opensourceleg.tools.utilities as utilities
-from opensourceleg.hardware.joints import Joint, MockJoint
-from opensourceleg.hardware.sensors import Loadcell, MockLoadcell
-from opensourceleg.tools.logger import Logger
-from opensourceleg.tools.utilities import SoftRealtimeLoop
+from .hardware.joints import Joint, MockJoint
+from .hardware.sensors import Loadcell, MockLoadcell
+from .tools import utilities
+from .tools.logger import Logger
+from .tools.utilities import SoftRealtimeLoop
 
 
 class OpenSourceLeg:


### PR DESCRIPTION
I installed the branch of this repo using `pip3.9 install git+https://github.com/tkevinbest/opensourceleg_dev.git@dev_relative_paths`

Tested functionality afterwards using this script in a different folder without access to repo files. This ensured that it was using my test branch as the pip version. 
```
# test_osl_basic.py

# Import OSL packages
from opensourceleg.osl import OpenSourceLeg
import numpy as np

# Initialization
osl = OpenSourceLeg(frequency=200)

use_offline_mode = True
osl.add_joint("knee", gear_ratio=9 * 83 / 18, port=None, offline_mode=use_offline_mode)
osl.add_joint(
    "ankle", gear_ratio=9 * 83 / 18, port="todo", offline_mode=use_offline_mode
)
LOADCELL_MATRIX = np.array(
    [
        (-38.72600, -1817.74700, 9.84900, 43.37400, -44.54000, 1824.67000),
        (-8.61600, 1041.14900, 18.86100, -2098.82200, 31.79400, 1058.6230),
        (-1047.16800, 8.63900, -1047.28200, -20.70000, -1073.08800, -8.92300),
        (20.57600, -0.04000, -0.24600, 0.55400, -21.40800, -0.47600),
        (-12.13400, -1.10800, 24.36100, 0.02300, -12.14100, 0.79200),
        (-0.65100, -28.28700, 0.02200, -25.23000, 0.47300, -27.3070),
    ]
)
osl.add_loadcell(
    joint=osl.knee, offline_mode=use_offline_mode, loadcell_matrix=LOADCELL_MATRIX
)

with osl:
    osl.home()
    osl.calibrate_loadcell()
    osl.knee.set_mode(osl.knee.control_modes.impedance)
    osl.ankle.set_mode(osl.knee.control_modes.impedance)

    # Main Loop
    for t in osl.clock:
        osl.update()
        print(osl.knee.output_position)
```